### PR TITLE
Switch from internal port to all ports defined

### DIFF
--- a/lib/wmi.c
+++ b/lib/wmi.c
@@ -686,7 +686,7 @@ create_wmi_port(char *name) {
 
     /* Check if the element already exists on the switch. */
     wchar_t internal_port_query[WMI_QUERY_COUNT] = L"SELECT * FROM "
-    L"Msvm_InternalEthernetPort WHERE ElementName = \"";
+    L"CIM_EthernetPort WHERE ElementName = \"";
 
     wide_name = xmalloc((strlen(name) + 1) * sizeof(wchar_t));
 


### PR DESCRIPTION
This patch changes the way we try to figure out if a port is defined on a given switch.

Instead of looking only in the internal ports defined switch to all ports defined.

This caused issues when trying to add a Hyper-V container port to a given OVS bridge.

Reported-by: Danting Liu <dantingl@vmware.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Acked-by: Anand Kumar <kumaranand@vmware.com>